### PR TITLE
🪳 Fix error handling gaps in deploy scripts and entrypoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,12 +166,18 @@ jobs:
               fi
               if [ "$i" -eq 30 ]; then
                 echo "ERROR: Container failed to become ready after 30 attempts"
+                echo "--- Final health check output ---"
+                docker compose exec -T app php artisan --version || true
                 docker compose logs --tail=50 app
                 exit 1
               fi
               echo "Attempt ${i}/30: container not ready, waiting..."
               sleep 2
             done
+            docker compose exec -T app test -d /var/www/html/public/build || {
+              echo "ERROR: /var/www/html/public/build not found in container, aborting asset copy"
+              exit 1
+            }
             rm -rf public/build && mkdir -p public/build
             docker compose cp app:/var/www/html/public/build/. public/build/
 
@@ -212,11 +218,17 @@ jobs:
               fi
               if [ "$i" -eq 30 ]; then
                 echo "ERROR: Container failed to become ready after 30 attempts"
+                echo "--- Final health check output ---"
+                docker compose exec -T app php artisan --version || true
                 docker compose logs --tail=50 app
                 exit 1
               fi
               echo "Attempt ${i}/30: container not ready, waiting..."
               sleep 2
             done
+            docker compose exec -T app test -d /var/www/html/public/build || {
+              echo "ERROR: /var/www/html/public/build not found in container, aborting asset copy"
+              exit 1
+            }
             rm -rf public/build && mkdir -p public/build
             docker compose cp app:/var/www/html/public/build/. public/build/

--- a/.github/workflows/dependabot-make-release.yml
+++ b/.github/workflows/dependabot-make-release.yml
@@ -83,6 +83,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
+          PR_STATE=$(gh pr view dependabot-updates --json state --jq '.state' 2>/dev/null || echo "NOT_FOUND")
+          if [ "$PR_STATE" != "OPEN" ]; then
+            echo "No open PR for dependabot-updates (state: $PR_STATE), creating one..."
+            gh pr create --base main --head dependabot-updates \
+              --title "chore: bump dependencies" \
+              --body "Automated dependency updates"
+          fi
           gh pr ready dependabot-updates
           gh pr checks dependabot-updates --watch --fail-fast
           gh pr merge dependabot-updates --merge

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,11 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           LS_REMOTE_OUTPUT=$(git ls-remote --tags origin "$NEXT_VERSION")
           if echo "$LS_REMOTE_OUTPUT" | grep -qF "refs/tags/$NEXT_VERSION"; then
-            echo "Tag $NEXT_VERSION already exists, aborting"
+            echo "ERROR: Tag $NEXT_VERSION already exists on remote."
+            echo "A previous run may have pushed the tag but failed before creating the GitHub Release."
+            echo "Recovery options:"
+            echo "  1. If the GitHub Release is missing: create it manually at https://github.com/${GITHUB_REPOSITORY}/releases/new?tag=${NEXT_VERSION}"
+            echo "  2. If you want to re-run: delete the remote tag with: git push origin :refs/tags/${NEXT_VERSION}"
             exit 1
           fi
           git tag -a "$NEXT_VERSION" -m "Release $NEXT_VERSION"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,15 +10,24 @@ echo "[entrypoint] Creating storage directories..."
 mkdir -p storage/framework/cache storage/framework/sessions storage/framework/views storage/logs storage/app/public
 
 echo "[entrypoint] Caching config..."
-php artisan config:cache
+php artisan config:cache || {
+    echo "[entrypoint] ERROR: php artisan config:cache failed" >&2
+    exit 1
+}
 
 echo "[entrypoint] Caching views..."
-php artisan view:cache
+php artisan view:cache || {
+    echo "[entrypoint] ERROR: php artisan view:cache failed" >&2
+    exit 1
+}
 
 # Set RUN_MIGRATIONS=false on additional replicas to avoid concurrent migration attempts.
 if [ "${RUN_MIGRATIONS:-true}" = "true" ]; then
     echo "[entrypoint] Running migrations..."
-    php artisan migrate --force
+    php artisan migrate --force || {
+        echo "[entrypoint] ERROR: php artisan migrate --force failed" >&2
+        exit 1
+    }
 fi
 
 echo "[entrypoint] Starting PHP-FPM..."


### PR DESCRIPTION
## Summary

Backport of fixes identified during a PR review of [istic/wereabouts#216](https://github.com/istic/wereabouts/pull/216).

- **ci.yml**: readiness loop now re-runs the health check unredirected on the final timeout, so misconfiguration errors (wrong service name, permission issues) are distinguishable from "container slow to start"; container build path verified before destructive `rm -rf public/build`
- **release.yml**: "tag already exists" abort message now includes recovery steps (create release manually or delete the tag to re-run)
- **dependabot-make-release.yml**: checks for an open PR before calling `gh pr ready`/`gh pr merge`; creates one if missing, preventing a confusing failure when the branch exists but has no associated PR
- **docker/entrypoint.sh**: artisan commands wrapped with `[entrypoint] ERROR:` messages for consistency with the existing `APP_KEY` check

## Test plan

- [ ] Trigger a staging deploy and confirm readiness loop output is unchanged on success
- [ ] Verify `dependabot-make-release.yml` runs cleanly on next Monday schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)