### PR TITLE
Restore dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/auto-rebase-dependabot.yml
+++ b/.github/workflows/auto-rebase-dependabot.yml
@@ -5,10 +5,13 @@ on:
     - cron: "0 1 * * *"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   rebase:
     uses: istic/shared-workflows/.github/workflows/auto-rebase-dependabot.yml@main
     permissions:
       contents: write
       pull-requests: write
-    secrets: inherit # pragma: allowlist secret
+    secrets:
+      REBASE_TOKEN: ${{ secrets.REBASE_TOKEN }} # pragma: allowlist secret

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,15 @@
+name: "[Auto] Merge Dependabot Updates"
+
+on:
+  pull_request:
+    branches: [dependabot-updates]
+
+permissions: {}
+
+jobs:
+  automerge:
+    if: github.actor == 'dependabot[bot]'
+    uses: istic/shared-workflows/.github/workflows/auto-merge-dependabot.yml@main
+    permissions:
+      pull-requests: write
+      contents: write


### PR DESCRIPTION
## Summary

- Diagnosed why the dependabot automerge pipeline appears broken: commit `43d67c9` ("Replace CI with Sprouter-style build/push/deploy workflows") deleted the old `automerge.yml` when the CI was rewritten, but nothing replaced its job of merging individual `dependabot/*` PRs into the `dependabot-updates` branch. That's caused 15+ dependabot PRs to pile up unmerged since June, which in turn makes the daily `auto-rebase-dependabot.yml` job hit a stale `package-lock.json` conflict, and makes the weekly `dependabot-make-release.yml` job fail because it finds no CI checks on `dependabot-updates`.
- Added `.github/workflows/dependabot-auto-merge.yml`, ported from `istic/laravel-starter-kit`'s current reference implementation — it auto-merges dependabot PRs into `dependabot-updates` via `istic/shared-workflows`'s reusable `auto-merge-dependabot.yml` once their checks pass.
- Updated `auto-rebase-dependabot.yml` to pass `REBASE_TOKEN` explicitly (matching the reference) instead of a blanket `secrets: inherit`. Pushes made with the default `GITHUB_TOKEN` don't trigger downstream workflow runs, which is why pushes to `dependabot-updates` were never kicking off CI, causing the weekly release job's `gh pr checks --watch` to see nothing.

## Still needs manual attention (not done in this PR)

- **`REBASE_TOKEN` secret**: confirm a PAT is configured as a repo secret named `REBASE_TOKEN` (Settings → Secrets and variables → Actions). Without it, the rebase job falls back to `github.token`, which won't trigger CI on push.
- **Existing backlog**: 15 dependabot PRs are currently stuck open against `dependabot-updates` (oldest since June 5), and the `dependabot-updates` branch itself has a rebase conflict in `package-lock.json` (replaying a jshint bump commit) blocking it from advancing onto `main`. These need manual review/resolution — didn't want to force-push or bulk-merge a shared branch without sign-off.

## Test plan

- [ ] Confirm `REBASE_TOKEN` secret exists in repo settings
- [ ] Manually resolve the `dependabot-updates` rebase conflict / clear the backlog
- [ ] Watch the next dependabot PR to confirm `dependabot-auto-merge.yml` fires and merges it into `dependabot-updates`
- [ ] Confirm the next scheduled `auto-rebase-dependabot.yml` and `dependabot-make-release.yml` runs succeed

---
_Generated by [Claude Code](https://claude.ai/code/session_017CLrNvFk6wW4aUbdkdEZJ8)_