### PR TITLE
Auto-regenerate lockfiles when merging dependabot-updates into main

### DIFF
--- a/.github/workflows/dependabot-make-release.yml
+++ b/.github/workflows/dependabot-make-release.yml
@@ -78,6 +78,70 @@ jobs:
       checks: read
 
     steps:
+      - name: Checkout dependabot-updates
+        uses: actions/checkout@v4
+        with:
+          ref: dependabot-updates
+          fetch-depth: 0
+          token: ${{ secrets.REBASE_TOKEN || github.token }} # pragma: allowlist secret
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer:v2
+          extensions: redis,opentelemetry
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Merge main into dependabot-updates, regenerating lockfiles on conflict
+        run: |
+          set -e
+          git fetch origin main
+          if git merge origin/main --no-edit; then
+            echo "Merged main into dependabot-updates cleanly"
+            exit 0
+          fi
+
+          CONFLICTS=$(git diff --name-only --diff-filter=U)
+          echo "Conflicting files:"
+          echo "$CONFLICTS"
+
+          NON_LOCKFILE_CONFLICTS=$(echo "$CONFLICTS" | grep -vE '^(composer\.lock|package-lock\.json)$' || true)
+          if [ -n "$NON_LOCKFILE_CONFLICTS" ]; then
+            echo "::error::Conflicts outside of composer.lock/package-lock.json need manual resolution:"
+            echo "$NON_LOCKFILE_CONFLICTS"
+            git merge --abort
+            exit 1
+          fi
+
+          if echo "$CONFLICTS" | grep -qx 'composer.lock'; then
+            echo "Regenerating composer.lock"
+            rm -f composer.lock
+            composer update --no-interaction
+            git add composer.lock
+          fi
+
+          if echo "$CONFLICTS" | grep -qx 'package-lock.json'; then
+            echo "Regenerating package-lock.json"
+            rm -f package-lock.json
+            npm install
+            git add package-lock.json
+          fi
+
+          git commit --no-edit
+
+      - name: Push resolved dependabot-updates
+        run: git push origin dependabot-updates
+
       - name: Merge dependabot-updates PR into main
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/dependabot-make-release.yml
+++ b/.github/workflows/dependabot-make-release.yml
@@ -115,6 +115,12 @@ jobs:
           echo "Conflicting files:"
           echo "$CONFLICTS"
 
+          if [ -z "$CONFLICTS" ]; then
+            echo "::error::Merge failed but no conflicted files were found - not a simple content conflict, needs manual investigation"
+            git merge --abort
+            exit 1
+          fi
+
           NON_LOCKFILE_CONFLICTS=$(echo "$CONFLICTS" | grep -vE '^(composer\.lock|package-lock\.json)$' || true)
           if [ -n "$NON_LOCKFILE_CONFLICTS" ]; then
             echo "::error::Conflicts outside of composer.lock/package-lock.json need manual resolution:"
@@ -126,14 +132,14 @@ jobs:
           if echo "$CONFLICTS" | grep -qx 'composer.lock'; then
             echo "Regenerating composer.lock"
             rm -f composer.lock
-            composer update --no-interaction
+            composer update --no-interaction --no-scripts
             git add composer.lock
           fi
 
           if echo "$CONFLICTS" | grep -qx 'package-lock.json'; then
             echo "Regenerating package-lock.json"
             rm -f package-lock.json
-            npm install
+            npm install --package-lock-only --ignore-scripts --no-audit --no-fund
             git add package-lock.json
           fi
 


### PR DESCRIPTION
## Summary

- Follow-up to #218. `dependabot-updates` and `main` have independently accumulated dependency bumps (30+ commits only on `dependabot-updates`, several merged straight to `main`), so `composer.lock`/`package-lock.json` have diverged and conflict. That's currently blocking everything: the daily rebase job fails outright, and the weekly `[Dependabot] Make Release` job's `gh pr merge` can't merge a conflicting PR.
- Since lockfiles are generated artifacts, there's no reason a human needs to resolve those conflicts by hand every time this happens.
- The `merge-dependabot` job in `dependabot-make-release.yml` now merges `main` into `dependabot-updates` itself before attempting `gh pr merge`. If that merge conflicts **only** in `composer.lock` and/or `package-lock.json`, it deletes and regenerates them via `composer update` / `npm install` and commits the merge. Conflicts anywhere else (manifests, source, Dockerfile) still abort the job so a human resolves them — only the generated lockfiles are auto-resolved.
- The push uses `REBASE_TOKEN` (falling back to the default token), same reasoning as the rebase job in #218: a push made with the default `GITHUB_TOKEN` doesn't trigger downstream CI, and this job needs the push to `dependabot-updates` to actually kick off checks before it calls `gh pr checks --watch`.

## Out of scope / still true

- The **daily** `auto-rebase-dependabot.yml` job isn't touched here and will keep failing on the same conflict until this PR lands and a Monday run (or manual `workflow_dispatch`) resolves it — after that, `dependabot-updates` and `main` should be back in sync and the daily rebase should go back to being a no-op most days.
- This doesn't retroactively fix the currently-open `dependabot-updates` → `main` PR (#164); the next scheduled or manually-dispatched run of `[Dependabot] Make Release` will exercise this new logic against it.

## Test plan

- [ ] Manually trigger `[Dependabot] Make Release` via `workflow_dispatch` (with `merge_dependabot: true`) and confirm the lockfile-conflict path runs and resolves cleanly
- [ ] Confirm CI passes on the resulting `dependabot-updates` commit
- [ ] Confirm PR #164 merges into `main`
- [ ] Confirm the following day's `auto-rebase-dependabot.yml` run is a clean no-op

---
_Generated by [Claude Code](https://claude.ai/code/session_017CLrNvFk6wW4aUbdkdEZJ8)_