### PR TITLE
🪳 Fix suncalc v2 build failure by switching to namespace import

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,9 @@
 - Default database switched from SQLite to MySQL (matching production deployment model)
 - GitHub Actions workflows replaced with self-contained release and Dependabot automation matching Sprouter's model
 
+### Fixed
+- Production build failure after `suncalc` upgraded to v2 and dropped its CommonJS default export in favor of named-only ESM exports; switched to a namespace import (`import * as SunCalc from "suncalc"`) that works against both v1 and v2
+
 ## [2.2.0] - 2026-04-06
 
 ### Added

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -4,7 +4,7 @@ import "./ios12-polyfills.js";
 import twemoji from "@twemoji/api";
 // Import external libraries from node_modules
 import ICAL from "ical.js";
-import SunCalc from "suncalc";
+import * as SunCalc from "suncalc";
 import "emoji-picker-element";
 
 // Make libraries available globally BEFORE importing application files


### PR DESCRIPTION
## Summary
- Dependabot's `suncalc` bump (^1.9.0 → ^2.0.1, part of this branch) dropped the package's CommonJS default export in favor of named-only ESM exports, breaking the production build with `[MISSING_EXPORT] "default" is not exported by "node_modules/suncalc/index.js"` at `resources/js/app.js:7`.
- Fixes it by switching to `import * as SunCalc from "suncalc"`, which works against both v1's `module.exports` object and v2's named exports since both expose the same method names (`getTimes`, `getMoonPosition`, etc). No other call sites (`SunCalc.getTimes(...)` in docket-ui.js) need to change.
- Verified locally: `npm run build` succeeds with this change against both suncalc v1 (main) and v2 (this branch), and `getTimes` is present in the built bundle.

Unblocks PR #164 and its sub-PRs (#224, #225, #226), which currently all fail CI on this same error.

## Test plan
- [x] `npm run build` succeeds on `dependabot-updates` (suncalc v2)
- [x] `npm run build` succeeds on `main` (suncalc v1) — confirms the change doesn't require the version bump
- [x] `getTimes` symbol present in built `app-*.js` bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)