### PR TITLE
Composer & NPM Updates

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8089,16 +8089,16 @@
         },
         {
             "name": "laravel/mcp",
-            "version": "v0.9.2",
+            "version": "v0.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/mcp.git",
-                "reference": "2bb70c3662dfc2e2ff55c38a10ddf55bed2443b3"
+                "reference": "534b29f18418673033ec918c5a840b6ce9c08327"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/mcp/zipball/2bb70c3662dfc2e2ff55c38a10ddf55bed2443b3",
-                "reference": "2bb70c3662dfc2e2ff55c38a10ddf55bed2443b3",
+                "url": "https://api.github.com/repos/laravel/mcp/zipball/534b29f18418673033ec918c5a840b6ce9c08327",
+                "reference": "534b29f18418673033ec918c5a840b6ce9c08327",
                 "shasum": ""
             },
             "require": {
@@ -8159,20 +8159,20 @@
                 "issues": "https://github.com/laravel/mcp/issues",
                 "source": "https://github.com/laravel/mcp"
             },
-            "time": "2026-08-06T15:59:47+00:00"
+            "time": "2026-08-10T18:01:31+00:00"
         },
         {
             "name": "laravel/pint",
-            "version": "v1.30.4",
+            "version": "v1.30.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "a96cb6eee2961905d2fce7207aefb80945bf6b28"
+                "reference": "fe4148c503a0e266353d61396b79bbf7f35122df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/a96cb6eee2961905d2fce7207aefb80945bf6b28",
-                "reference": "a96cb6eee2961905d2fce7207aefb80945bf6b28",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/fe4148c503a0e266353d61396b79bbf7f35122df",
+                "reference": "fe4148c503a0e266353d61396b79bbf7f35122df",
                 "shasum": ""
             },
             "require": {
@@ -8180,19 +8180,19 @@
                 "ext-mbstring": "*",
                 "ext-tokenizer": "*",
                 "ext-xml": "*",
-                "php": "^8.2.0"
+                "php": "^8.3.0"
             },
             "require-dev": {
                 "composer/semver": "^3.4.4",
                 "friendsofphp/php-cs-fixer": "^3.95.18",
-                "illuminate/view": "^12.65.0",
+                "illuminate/view": "^13.24.0",
                 "larastan/larastan": "^3.10.0",
-                "laravel-zero/framework": "^12.1.0",
+                "laravel-zero/framework": "^13.0.0",
                 "laravel/agent-detector": "^2.0.2",
                 "laravel/prompts": "^0.3.22",
                 "mockery/mockery": "^1.6.12",
                 "nunomaduro/termwind": "^2.4.0",
-                "pestphp/pest": "^3.8.7"
+                "pestphp/pest": "^4.7.8"
             },
             "bin": [
                 "builds/pint"
@@ -8229,7 +8229,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2026-08-05T16:47:22+00:00"
+            "time": "2026-08-10T15:35:50+00:00"
         },
         {
             "name": "laravel/roster",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"@biomejs/biome": "2.5.5",
 				"@vitejs/plugin-legacy": "^8.0.0",
 				"core-js": "^3.48.0",
-				"jshint": "^0.5.9",
+				"jshint": "^2.13.6",
 				"laravel-vite-plugin": "^3.0.1",
 				"regenerator-runtime": "^0.14.1",
 				"stylelint": "^17.0.0",
@@ -4291,15 +4291,6 @@
 			"dev": true,
 			"license": "Python-2.0"
 		},
-		"node_modules/argsparser": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/argsparser/-/argsparser-0.0.7.tgz",
-			"integrity": "sha512-jWiKKi8EwhvFhtyY+2x5Y4zOa2Wp93mhQ++0MxcLF/SJNlmf5kro81o/3juM9iQOa6pE/poHAGKl5vP7Cbn8Dg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.2.0"
-			}
-		},
 		"node_modules/astral-regex": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -4328,14 +4319,11 @@
 			}
 		},
 		"node_modules/balanced-match": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
+			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
 			"version": "2.11.13",
@@ -4351,16 +4339,14 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.9",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^4.0.2"
-			},
-			"engines": {
-				"node": "20 || >=22"
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
 			}
 		},
 		"node_modules/braces": {
@@ -4497,6 +4483,20 @@
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
+		"node_modules/cli": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+			"integrity": "sha512-41U72MB56TfUMGndAKK8vJ78eooOD4Z5NOL4xEfjc0c23s+6EYKXlXsmACBVclLP1yOfWCgEganVzddVrSNoTg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"exit": "0.1.2",
+				"glob": "^7.1.1"
+			},
+			"engines": {
+				"node": ">=0.2.5"
+			}
+		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4531,6 +4531,22 @@
 			"dev": true,
 			"license": "MIT",
 			"peer": true
+		},
+		"node_modules/concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/console-browserify": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+			"integrity": "sha512-duS7VP5pvfsNLDvL1O4VOEbw37AI3A4ZUQYemvDlnpGrNu9tprR7BYWpDYwC0Xia0Zxz5ZupdiIrUp0GH1aXfg==",
+			"dev": true,
+			"dependencies": {
+				"date-now": "^0.1.4"
+			}
 		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
@@ -4570,6 +4586,13 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/core-js"
 			}
+		},
+		"node_modules/core-util-is": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/cosmiconfig": {
 			"version": "9.0.2",
@@ -4635,6 +4658,12 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/date-now": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+			"integrity": "sha512-AsElvov3LoNB7tf5k37H2jYSB+ZZPMT5sG2QjJCcdlV5chIv6htBUBUui2IKRjgtKAKtCBN7Zbwa+MtwLjSeNw==",
+			"dev": true
+		},
 		"node_modules/debug": {
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4661,6 +4690,66 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/dom-serializer": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+			"integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.0.1",
+				"entities": "^2.0.0"
+			}
+		},
+		"node_modules/dom-serializer/node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/dom-serializer/node_modules/entities": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+			"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/domelementtype": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/domhandler": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+			"integrity": "sha512-q9bUwjfp7Eif8jWxxxPSykdRZAb6GkguBGSgvvCrhI9wB71W2K/Kvv4E61CF/mcCfnVJDeDWx/Vb/uAqbDj6UQ==",
+			"dev": true,
+			"dependencies": {
+				"domelementtype": "1"
+			}
+		},
+		"node_modules/domutils": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+			"integrity": "sha512-gSu5Oi/I+3wDENBsOWBiRK1eoGxcywYSqg3rR960/+EfY0CF4EX1VPkgHOZ3WiS/Jg2DtliF6BhWcHlfpYUcGw==",
+			"dev": true,
+			"dependencies": {
+				"dom-serializer": "0",
+				"domelementtype": "1"
 			}
 		},
 		"node_modules/electron-to-chromium": {
@@ -4692,6 +4781,13 @@
 			"engines": {
 				"node": ">=14"
 			}
+		},
+		"node_modules/entities": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+			"integrity": "sha512-LbLqfXgJMmy81t+7c14mnulFHJ170cM6E+0vMXR9k/ZiZwgX8i5pNgjTCX3SO4VeUsFLV+8InixoretwU+MjBQ==",
+			"dev": true,
+			"license": "BSD-like"
 		},
 		"node_modules/env-paths": {
 			"version": "2.2.1",
@@ -4741,6 +4837,15 @@
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/exit": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+			"integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8.0"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -4886,6 +4991,13 @@
 				"graceful-fs": "^4.1.6"
 			}
 		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4934,6 +5046,28 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/glob-parent": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -4945,6 +5079,19 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/glob/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/global-modules": {
@@ -5068,6 +5215,20 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/htmlparser2": {
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+			"integrity": "sha512-hBxEg3CYXe+rPIua8ETe7tmG3XDn9B0edOE/e9wH2nLczxzgdu0m0aNHY+5wFZiviLWLdANPJTssa92dMcXQ5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "1",
+				"domhandler": "2.3",
+				"domutils": "1.5",
+				"entities": "1.0",
+				"readable-stream": "1.1"
+			}
+		},
 		"node_modules/ical.js": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.2.1.tgz",
@@ -5117,6 +5278,25 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
 			}
+		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/ini": {
 			"version": "1.3.8",
@@ -5203,6 +5383,13 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/isarray": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+			"integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5254,19 +5441,22 @@
 			}
 		},
 		"node_modules/jshint": {
-			"version": "0.5.9",
-			"resolved": "https://registry.npmjs.org/jshint/-/jshint-0.5.9.tgz",
-			"integrity": "sha512-i/mir4CHUfEzwU0qIonfYT25AALitakjbBQJuL3+OZlE15AsL61gND3bcWzgPg2uW6WFKC8ALe5wbL+h22M1wA==",
+			"version": "2.13.6",
+			"resolved": "https://registry.npmjs.org/jshint/-/jshint-2.13.6.tgz",
+			"integrity": "sha512-IVdB4G0NTTeQZrBoM8C5JFVLjV2KtZ9APgybDA1MK73xb09qFs0jCXyQLnCOp1cSZZZbvhq/6mfXHUTaDkffuQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"argsparser": ">=0.0.3",
-				"minimatch": ">=0.0.4"
+				"cli": "~1.0.0",
+				"console-browserify": "1.1.x",
+				"exit": "0.1.x",
+				"htmlparser2": "3.8.x",
+				"lodash": "~4.17.21",
+				"minimatch": "~3.0.2",
+				"strip-json-comments": "1.0.x"
 			},
 			"bin": {
-				"jshint": "bin/hint"
-			},
-			"engines": {
-				"node": "*"
+				"jshint": "bin/jshint"
 			}
 		},
 		"node_modules/json-parse-even-better-errors": {
@@ -5635,6 +5825,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/lodash": {
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -5738,19 +5935,16 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "10.2.6",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
-			"integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+			"integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
 			"dev": true,
-			"license": "BlueOak-1.0.0",
+			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^5.0.8"
+				"brace-expansion": "^1.1.7"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+				"node": "*"
 			}
 		},
 		"node_modules/ms": {
@@ -5820,6 +6014,16 @@
 				"node": ">=12.20.0"
 			}
 		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5883,6 +6087,16 @@
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/path-parse": {
 			"version": "1.0.7",
@@ -6028,6 +6242,19 @@
 				}
 			],
 			"license": "MIT"
+		},
+		"node_modules/readable-stream": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+			"integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.1",
+				"isarray": "0.0.1",
+				"string_decoder": "~0.10.x"
+			}
 		},
 		"node_modules/readdirp": {
 			"version": "5.1.1",
@@ -6326,6 +6553,13 @@
 				"source-map": "^0.6.0"
 			}
 		},
+		"node_modules/string_decoder": {
+			"version": "0.10.31",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+			"integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/string-width": {
 			"version": "8.2.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
@@ -6357,6 +6591,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/strip-json-comments": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+			"integrity": "sha512-AOPG8EBc5wAikaG1/7uFCNFJwnKOuQwFTpYBdTW6OvWHeZBQBrAA/amefHGrEiOnCPcLFZK6FUPtWVKpQVIRgg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"strip-json-comments": "cli.js"
+			},
+			"engines": {
+				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/stylelint": {
@@ -6877,6 +7124,13 @@
 			"bin": {
 				"which": "bin/which"
 			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/write-file-atomic": {
 			"version": "7.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"@biomejs/biome": "2.5.5",
 				"@vitejs/plugin-legacy": "^8.0.0",
 				"core-js": "^3.48.0",
-				"jshint": "^2.13.6",
+				"jshint": "^0.5.9",
 				"laravel-vite-plugin": "^3.0.1",
 				"regenerator-runtime": "^0.14.1",
 				"stylelint": "^17.0.0",
@@ -1565,6 +1565,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1582,6 +1585,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1599,6 +1605,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1616,6 +1625,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2101,6 +2113,9 @@
 			"cpu": [
 				"arm"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2120,6 +2135,9 @@
 			"integrity": "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==",
 			"cpu": [
 				"arm"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2141,6 +2159,9 @@
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2160,6 +2181,9 @@
 			"integrity": "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2181,6 +2205,9 @@
 			"cpu": [
 				"x64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2200,6 +2227,9 @@
 			"integrity": "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2347,6 +2377,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2364,6 +2397,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2381,6 +2417,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2398,6 +2437,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2415,6 +2457,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2432,6 +2477,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4243,6 +4291,15 @@
 			"dev": true,
 			"license": "Python-2.0"
 		},
+		"node_modules/argsparser": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/argsparser/-/argsparser-0.0.7.tgz",
+			"integrity": "sha512-jWiKKi8EwhvFhtyY+2x5Y4zOa2Wp93mhQ++0MxcLF/SJNlmf5kro81o/3juM9iQOa6pE/poHAGKl5vP7Cbn8Dg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.2.0"
+			}
+		},
 		"node_modules/astral-regex": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -4271,11 +4328,14 @@
 			}
 		},
 		"node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
 		},
 		"node_modules/baseline-browser-mapping": {
 			"version": "2.11.13",
@@ -4291,14 +4351,16 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.18",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/braces": {
@@ -4435,20 +4497,6 @@
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
-		"node_modules/cli": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
-			"integrity": "sha512-41U72MB56TfUMGndAKK8vJ78eooOD4Z5NOL4xEfjc0c23s+6EYKXlXsmACBVclLP1yOfWCgEganVzddVrSNoTg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"exit": "0.1.2",
-				"glob": "^7.1.1"
-			},
-			"engines": {
-				"node": ">=0.2.5"
-			}
-		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4483,22 +4531,6 @@
 			"dev": true,
 			"license": "MIT",
 			"peer": true
-		},
-		"node_modules/concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/console-browserify": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-			"integrity": "sha512-duS7VP5pvfsNLDvL1O4VOEbw37AI3A4ZUQYemvDlnpGrNu9tprR7BYWpDYwC0Xia0Zxz5ZupdiIrUp0GH1aXfg==",
-			"dev": true,
-			"dependencies": {
-				"date-now": "^0.1.4"
-			}
 		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
@@ -4538,13 +4570,6 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/core-js"
 			}
-		},
-		"node_modules/core-util-is": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/cosmiconfig": {
 			"version": "9.0.2",
@@ -4610,12 +4635,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/date-now": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-			"integrity": "sha512-AsElvov3LoNB7tf5k37H2jYSB+ZZPMT5sG2QjJCcdlV5chIv6htBUBUui2IKRjgtKAKtCBN7Zbwa+MtwLjSeNw==",
-			"dev": true
-		},
 		"node_modules/debug": {
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4642,66 +4661,6 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/dom-serializer": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-			"integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"domelementtype": "^2.0.1",
-				"entities": "^2.0.0"
-			}
-		},
-		"node_modules/dom-serializer/node_modules/domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"license": "BSD-2-Clause"
-		},
-		"node_modules/dom-serializer/node_modules/entities": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-			"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/domelementtype": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-			"dev": true,
-			"license": "BSD-2-Clause"
-		},
-		"node_modules/domhandler": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-			"integrity": "sha512-q9bUwjfp7Eif8jWxxxPSykdRZAb6GkguBGSgvvCrhI9wB71W2K/Kvv4E61CF/mcCfnVJDeDWx/Vb/uAqbDj6UQ==",
-			"dev": true,
-			"dependencies": {
-				"domelementtype": "1"
-			}
-		},
-		"node_modules/domutils": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-			"integrity": "sha512-gSu5Oi/I+3wDENBsOWBiRK1eoGxcywYSqg3rR960/+EfY0CF4EX1VPkgHOZ3WiS/Jg2DtliF6BhWcHlfpYUcGw==",
-			"dev": true,
-			"dependencies": {
-				"dom-serializer": "0",
-				"domelementtype": "1"
 			}
 		},
 		"node_modules/electron-to-chromium": {
@@ -4733,13 +4692,6 @@
 			"engines": {
 				"node": ">=14"
 			}
-		},
-		"node_modules/entities": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-			"integrity": "sha512-LbLqfXgJMmy81t+7c14mnulFHJ170cM6E+0vMXR9k/ZiZwgX8i5pNgjTCX3SO4VeUsFLV+8InixoretwU+MjBQ==",
-			"dev": true,
-			"license": "BSD-like"
 		},
 		"node_modules/env-paths": {
 			"version": "2.2.1",
@@ -4789,15 +4741,6 @@
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/exit": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-			"integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8.0"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -4943,13 +4886,6 @@
 				"graceful-fs": "^4.1.6"
 			}
 		},
-		"node_modules/fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4998,28 +4934,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/glob-parent": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -5031,19 +4945,6 @@
 			},
 			"engines": {
 				"node": ">= 6"
-			}
-		},
-		"node_modules/glob/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/global-modules": {
@@ -5167,20 +5068,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/htmlparser2": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
-			"integrity": "sha512-hBxEg3CYXe+rPIua8ETe7tmG3XDn9B0edOE/e9wH2nLczxzgdu0m0aNHY+5wFZiviLWLdANPJTssa92dMcXQ5Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"domelementtype": "1",
-				"domhandler": "2.3",
-				"domutils": "1.5",
-				"entities": "1.0",
-				"readable-stream": "1.1"
-			}
-		},
 		"node_modules/ical.js": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.2.1.tgz",
@@ -5230,25 +5117,6 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
 			}
-		},
-		"node_modules/inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
-		"node_modules/inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/ini": {
 			"version": "1.3.8",
@@ -5335,13 +5203,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/isarray": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-			"integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5393,22 +5254,19 @@
 			}
 		},
 		"node_modules/jshint": {
-			"version": "2.13.6",
-			"resolved": "https://registry.npmjs.org/jshint/-/jshint-2.13.6.tgz",
-			"integrity": "sha512-IVdB4G0NTTeQZrBoM8C5JFVLjV2KtZ9APgybDA1MK73xb09qFs0jCXyQLnCOp1cSZZZbvhq/6mfXHUTaDkffuQ==",
+			"version": "0.5.9",
+			"resolved": "https://registry.npmjs.org/jshint/-/jshint-0.5.9.tgz",
+			"integrity": "sha512-i/mir4CHUfEzwU0qIonfYT25AALitakjbBQJuL3+OZlE15AsL61gND3bcWzgPg2uW6WFKC8ALe5wbL+h22M1wA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"cli": "~1.0.0",
-				"console-browserify": "1.1.x",
-				"exit": "0.1.x",
-				"htmlparser2": "3.8.x",
-				"lodash": "~4.17.21",
-				"minimatch": "~3.0.2",
-				"strip-json-comments": "1.0.x"
+				"argsparser": ">=0.0.3",
+				"minimatch": ">=0.0.4"
 			},
 			"bin": {
-				"jshint": "bin/jshint"
+				"jshint": "bin/hint"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/json-parse-even-better-errors": {
@@ -5640,6 +5498,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -5661,6 +5522,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -5682,6 +5546,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -5703,6 +5570,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -5762,13 +5632,6 @@
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/lodash": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -5875,16 +5738,19 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
-			"integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+			"version": "10.2.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+			"integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "^5.0.8"
 			},
 			"engines": {
-				"node": "*"
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/ms": {
@@ -5954,16 +5820,6 @@
 				"node": ">=12.20.0"
 			}
 		},
-		"node_modules/once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"wrappy": "1"
-			}
-		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6027,16 +5883,6 @@
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/path-parse": {
 			"version": "1.0.7",
@@ -6182,19 +6028,6 @@
 				}
 			],
 			"license": "MIT"
-		},
-		"node_modules/readable-stream": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-			"integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.1",
-				"isarray": "0.0.1",
-				"string_decoder": "~0.10.x"
-			}
 		},
 		"node_modules/readdirp": {
 			"version": "5.1.1",
@@ -6493,13 +6326,6 @@
 				"source-map": "^0.6.0"
 			}
 		},
-		"node_modules/string_decoder": {
-			"version": "0.10.31",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-			"integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/string-width": {
 			"version": "8.2.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
@@ -6531,19 +6357,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
-		},
-		"node_modules/strip-json-comments": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-			"integrity": "sha512-AOPG8EBc5wAikaG1/7uFCNFJwnKOuQwFTpYBdTW6OvWHeZBQBrAA/amefHGrEiOnCPcLFZK6FUPtWVKpQVIRgg==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"strip-json-comments": "cli.js"
-			},
-			"engines": {
-				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/stylelint": {
@@ -6913,9 +6726,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.0.tgz",
-			"integrity": "sha512-x/M6q3w4Ybp91CNaS4S69UnliqR3BzRpOT6LWbksjth0S/+jhfaPJsWjt/TewpT8j9eLIojUf5jr29WextHroA==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+			"integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -7064,13 +6877,6 @@
 			"bin": {
 				"which": "bin/which"
 			}
-		},
-		"node_modules/wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/write-file-atomic": {
 			"version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"@biomejs/biome": "2.5.5",
 		"@vitejs/plugin-legacy": "^8.0.0",
 		"core-js": "^3.48.0",
-		"jshint": "^0.5.9",
+		"jshint": "^2.13.6",
 		"laravel-vite-plugin": "^3.0.1",
 		"regenerator-runtime": "^0.14.1",
 		"stylelint": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -29,12 +29,16 @@
 		"@biomejs/biome": "2.5.5",
 		"@vitejs/plugin-legacy": "^8.0.0",
 		"core-js": "^3.48.0",
-		"jshint": "^2.13.6",
+		"jshint": "^0.5.9",
 		"laravel-vite-plugin": "^3.0.1",
 		"regenerator-runtime": "^0.14.1",
 		"stylelint": "^17.0.0",
 		"stylelint-config-standard": "^40.0.0",
 		"suncalc": "^2.0.1",
 		"vite": "^8.0.0"
+	},
+	"allowScripts": {
+		"@parcel/watcher@2.6.0": true,
+		"core-js@3.50.0": true
 	}
 }


### PR DESCRIPTION
This pull request updates the `package.json` to explicitly allow installation of specific versions of certain dependencies using the `allowScripts` field. This helps manage security and compliance for packages that require post-install scripts.

Dependency management:

* Added an `allowScripts` section to `package.json` to permit install scripts for `@parcel/watcher@2.6.0` and `core-js@3.50.0`.