### PR TITLE
🪳 Log Google OAuth callback failures

### DIFF
--- a/app/Http/Controllers/LoginController.php
+++ b/app/Http/Controllers/LoginController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Laravel\Socialite\Facades\Socialite;
 
@@ -72,6 +73,8 @@ class LoginController extends Controller
 
             return redirect()->intended(route('home'));
         } catch (\Exception $e) {
+            Log::error('Google OAuth callback failed', ['exception' => $e->getMessage(), 'trace' => $e->getTraceAsString()]);
+
             return redirect()->route('login')->with('error', 'Unable to login with Google. Please try again.');
         }
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 - Production build failure after `suncalc` upgraded to v2 and dropped its CommonJS default export in favor of named-only ESM exports; switched to a namespace import (`import * as SunCalc from "suncalc"`) that works against both v1 and v2
+- Google OAuth callback failures are now logged instead of being silently swallowed, so login errors (e.g. readonly database, misconfigured `GOOGLE_DEFAULT_ACCOUNT`) can be diagnosed from logs
 
 ## [2.2.0] - 2026-04-06
 

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Laravel\Socialite\Facades\Socialite;
 use Tests\TestCase;
 
 class AuthenticationTest extends TestCase
@@ -82,5 +84,23 @@ class AuthenticationTest extends TestCase
 
         $this->assertGuest();
         $response->assertRedirect(route('home'));
+    }
+
+    public function test_google_callback_failure_is_logged(): void
+    {
+        Socialite::shouldReceive('driver->user')
+            ->andThrow(new \Exception('invalid_grant'));
+
+        Log::shouldReceive('error')
+            ->once()
+            ->with('Google OAuth callback failed', \Mockery::on(fn ($context) => ($context['exception'] ?? null) === 'invalid_grant'
+                && array_key_exists('trace', $context)
+            ));
+
+        $response = $this->get('/auth/google/callback');
+
+        $this->assertGuest();
+        $response->assertRedirect(route('login'));
+        $response->assertSessionHas('error', 'Unable to login with Google. Please try again.');
     }
 }

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -88,7 +88,13 @@ class AuthenticationTest extends TestCase
 
     public function test_google_callback_failure_is_logged(): void
     {
-        Socialite::shouldReceive('driver->user')
+        Socialite::shouldReceive('driver')
+            ->once()
+            ->with('google')
+            ->andReturnSelf();
+
+        Socialite::shouldReceive('user')
+            ->once()
             ->andThrow(new \Exception('invalid_grant'));
 
         Log::shouldReceive('error')


### PR DESCRIPTION
## Summary
- The catch block in `LoginController::handleGoogleCallback()` silently swallowed exceptions, making login failures impossible to diagnose from logs.
- Adds `Log::error()` with the exception message and trace before redirecting back to `/login`, per the fix described in the issue (this was previously hand-added in production to diagnose a readonly SQLite DB + wrong `GOOGLE_DEFAULT_ACCOUNT` issue, then removed).
- Added `test_google_callback_failure_is_logged` to `AuthenticationTest`, mocking `Socialite::driver('google')->user()` to throw and asserting `Log::error` is called with the exception message/trace, plus the existing redirect + flash-error behavior.

Fixes #120

## Test plan
- [x] `vendor/bin/phpunit` — 51 tests pass (was 50), including new regression test
- [x] `vendor/bin/pint --test` passes
- [x] `vendor/bin/phpstan analyse` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)