### PR TITLE
📖 Record jshint removal in changelog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,9 @@
 ### Fixed
 - Production build failure after `suncalc` upgraded to v2 and dropped its CommonJS default export in favor of named-only ESM exports; switched to a namespace import (`import * as SunCalc from "suncalc"`) that works against both v1 and v2
 
+### Removed
+- Unused `jshint` devDependency and its dead `/* jshint ... */` header comments; it wasn't run by any script, pre-commit hook, or CI step, and Biome already covers JS/JSON linting
+
 ## [2.2.0] - 2026-04-06
 
 ### Added


### PR DESCRIPTION
## Summary
Follow-up to #230, which merged before Copilot's review comment (that the jshint removal wasn't tracked in `docs/CHANGELOG.md`) was addressed. Adds the missing `[Unreleased] > Removed` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)