### PR TITLE
Backport CI/deploy bug fixes from laravel-starter-kit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ on:
         type: string
         required: true
 
+permissions: {}
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/dependabot-make-release.yml
+++ b/.github/workflows/dependabot-make-release.yml
@@ -150,17 +150,31 @@ jobs:
 
       - name: Merge dependabot-updates PR into main
         env:
-          GH_TOKEN: ${{ github.token }}
+          # github.token cannot merge PRs (see CLAUDE.md); use the same PAT
+          # as auto-rebase-dependabot.yml for this class of operation.
+          GH_TOKEN: ${{ secrets.REBASE_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          PR_STATE=$(gh pr view dependabot-updates --json state --jq '.state' 2>/dev/null || echo "NOT_FOUND")
+          if ! PR_STATE_RAW=$(gh pr view dependabot-updates --json state --jq '.state' 2>&1); then
+            if echo "$PR_STATE_RAW" | grep -qi "no pull requests found"; then
+              PR_STATE="NOT_FOUND"
+            else
+              echo "ERROR: gh pr view failed: $PR_STATE_RAW" >&2
+              exit 1
+            fi
+          else
+            PR_STATE="$PR_STATE_RAW"
+          fi
           if [ "$PR_STATE" != "OPEN" ]; then
             echo "No open PR for dependabot-updates (state: $PR_STATE), creating one..."
             gh pr create --base main --head dependabot-updates \
               --title "chore: bump dependencies" \
               --body "Automated dependency updates"
           fi
-          gh pr ready dependabot-updates
+          PR_IS_DRAFT=$(gh pr view dependabot-updates --json isDraft --jq '.isDraft')
+          if [ "$PR_IS_DRAFT" = "true" ]; then
+            gh pr ready dependabot-updates
+          fi
           gh pr checks dependabot-updates --watch --fail-fast
           gh pr merge dependabot-updates --merge
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ on:
         description: 'Version bump type'
         required: true
 
+permissions: {}
+
 jobs:
   tag:
     runs-on: ubuntu-latest

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -15,6 +15,12 @@ php artisan config:cache || {
     exit 1
 }
 
+echo "[entrypoint] Caching routes..."
+php artisan route:cache || {
+    echo "[entrypoint] ERROR: php artisan route:cache failed" >&2
+    exit 1
+}
+
 echo "[entrypoint] Caching views..."
 php artisan view:cache || {
     echo "[entrypoint] ERROR: php artisan view:cache failed" >&2


### PR DESCRIPTION
## Summary
- `dependabot-make-release.yml` was using `github.token` to `gh pr merge`, which cannot merge PRs (see CLAUDE.md) — switched to `secrets.REBASE_TOKEN`, matching `auto-rebase-dependabot.yml`
- Same workflow: only call `gh pr ready` when the PR is actually a draft (was called unconditionally), and distinguish "no PR found" from a genuine `gh` failure instead of swallowing all errors
- Added explicit top-level `permissions: {}` to `release.yml` and `ci.yml` (all jobs already declare their own least-privilege permissions)
- `docker/entrypoint.sh` now runs `php artisan route:cache` alongside `config:cache`/`view:cache` on container boot

Found by diffing docket against `istic/laravel-starter-kit`, the new Laravel baseline for the org. Deliberately left out template-only genericization that doesn't fit docket as-is (dropping the Redis PHP extension — docket uses `REDIS_CLIENT=phpredis` in production, dropping Selenium — docket uses Dusk, Pest migration, Laravel 13 bump, Biome/PHPStan removal from pre-commit). Those are bigger, scoped decisions rather than drop-in fixes.

## Test plan
- [x] `pre-commit run actionlint` passes on all three modified workflow files
- [x] YAML parses cleanly (js-yaml)
- [x] `bash -n docker/entrypoint.sh` passes
- [ ] Confirm `REBASE_TOKEN` secret has `pull-requests:write` scope needed for `gh pr merge` (already used successfully by `auto-rebase-dependabot.yml`, so should be fine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)